### PR TITLE
SFW-369 Adapt generic wireframe to weak view

### DIFF
--- a/StanwoodCore/Protocols/MetaModule.swift
+++ b/StanwoodCore/Protocols/MetaModule.swift
@@ -32,16 +32,14 @@ import Foundation
 ///
 /// In other words this protocol is the *glue* which connects all the main types of a Module.
 /// More details
-/// - View: represents the View protocol of a module and is constrained to be the same of *Presenter.Viewable*
 /// - Action: represents the Action type of a module and is constrained to be the same of *Presenter.Actionable*
 /// - Parameter: represents the Parameter type of a module and is constrained to be the same of *Presenter.Parameter*
 /// - ViewController: represents the *UIViewController* of the current module which also must conform to *HasPresenter*
 /// - Presenter: represents the *Presenter* type of the current module which is constrained to be the same of *ViewController.Presenter*
 public protocol MetaModule {
-    associatedtype View where View == Presenter.Viewable
     associatedtype Action where Action == Presenter.Actionable
     associatedtype Parameter where Parameter == Presenter.Parameterable
-    associatedtype ViewController: HasPresenter & UIViewController
+    associatedtype ViewController: HasPresenter & UIViewController where ViewController == Presenter.Viewable
     associatedtype Presenter: Presentable where Presenter == ViewController.Presenter
     
 }

--- a/StanwoodCore/Protocols/Wireframe.swift
+++ b/StanwoodCore/Protocols/Wireframe.swift
@@ -43,14 +43,12 @@ open class Wireframe<M: MetaModule> {
     ///
     /// - Parameters:
     ///   - viewController: the view controller for the current module
-    ///   - view: the view (usually the view controller) for the current module
     ///   - actions: the actions for the current module
     ///   - parameters: the parameters for the current module
     public class func prepare(viewController: M.ViewController,
-                        view: M.View,
                         actions: M.Action,
                         parameters: M.Parameter) {
-        let presenter = M.Presenter.make(actions: actions, parameters: parameters, view: view)
+        let presenter = M.Presenter.make(actions: actions, parameters: parameters, view: viewController)
         viewController.presenter = presenter
     }
 }


### PR DESCRIPTION
# What has changed

Minor changes to make the generic Wireframe compatible with the weak `view` property in `Presenter`.

- Removed the `View` associated type from `MetaModule`.
- Added a constraint to to `MetaModule` to make `ViewController == Presenter.Viewable`.
- Jira ticket: [SFW-369](https://stanwood.atlassian.net/browse/SFW-369)